### PR TITLE
Fixed the processor to route relation to failure when it fails

### DIFF
--- a/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogic.java
+++ b/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogic.java
@@ -67,6 +67,7 @@ import com.marklogic.client.eval.ServerEvaluationCall;
 public class ExecuteScriptMarkLogic extends AbstractMarkLogicProcessor {
     public static final String MARKLOGIC_RESULT = "marklogic.result";
     public static final String MARKLOGIC_RESULTS_COUNT = "marklogic.results.count";
+    public static final String MARKLOGIC_RESULTS_ERROR = "marklogic.results.error";
 
     protected static Validator PATH_SCRIPT_VALIDATOR = new Validator() {
         @Override
@@ -174,6 +175,10 @@ public class ExecuteScriptMarkLogic extends AbstractMarkLogicProcessor {
     protected static final Relationship FAILURE = new Relationship.Builder().name("failure")
             .description("Failure Relationship").build();
 
+    protected static final Relationship ERROR = new Relationship.Builder().name("error")
+            .description("Flowfiles that trigger a run-time error during execution are routed to the error relationship")
+            .build();
+
     private static Charset UTF8 = Charset.forName("UTF-8");
 
     @Override
@@ -196,6 +201,7 @@ public class ExecuteScriptMarkLogic extends AbstractMarkLogicProcessor {
         relationships.add(LAST_RESULT);
         relationships.add(ORIGINAL);
         relationships.add(FAILURE);
+        relationships.add(ERROR);
         this.relationships = Collections.unmodifiableSet(relationships);
     }
 
@@ -302,7 +308,16 @@ public class ExecuteScriptMarkLogic extends AbstractMarkLogicProcessor {
                 session.transfer(lastFF, LAST_RESULT);
             }
             session.commitAsync();
+        } catch (com.marklogic.client.FailedRequestException ex) {
+            // If there's an error running the script, rolling back the session and trying again isn't likely to work.
+            // Instead, transfer the flowfile to ERROR so that the flow can handle the error. 
+            getLogger().info("Error in ExecuteScriptMarkLogic. Sending to ERROR");
+            logError(ex);
+            originalFF = session.putAttribute(originalFF, MARKLOGIC_RESULTS_ERROR, ex.getMessage());
+            session.transfer(originalFF, ERROR);
+            session.commitAsync();
         } catch (final Throwable t) {
+            // Other errors could mean that MarkLogic is unreachable or some other problem. Transfer to FAILURE. 
             logError(t);
             getLogger().info("Error Rolling back session " );
             session.transfer(originalFF, FAILURE);

--- a/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogicIT.java
+++ b/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ExecuteScriptMarkLogicIT.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.marklogic.processor;
+
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExecuteScriptMarkLogicIT extends AbstractMarkLogicIT {
+
+    @BeforeEach
+    public void beforeEach() {
+        super.setup();
+    }
+
+    @Test
+    public void simpleJS() {
+        TestRunner runner = super.getNewTestRunner(ExecuteScriptMarkLogic.class);
+        runner.setValidateExpressionUsage(false);
+
+        runner.setProperty(ExecuteScriptMarkLogic.EXECUTION_TYPE, ExecuteScriptMarkLogic.AV_JAVASCRIPT);
+        runner.setProperty(ExecuteScriptMarkLogic.RESULTS_DESTINATION, ExecuteScriptMarkLogic.AV_CONTENT);
+        runner.setProperty(ExecuteScriptMarkLogic.SCRIPT_BODY, "1 + 1");
+        runner.setProperty(ExecuteScriptMarkLogic.SKIP_FIRST, "false");
+
+
+        MockFlowFile mockFlowFile = new MockFlowFile(3);
+        Map<String, String> attributes = new HashMap<>();
+        mockFlowFile.putAttributes(attributes);
+
+        runner.enqueue(mockFlowFile);
+        runner.run(1);
+
+        runner.assertQueueEmpty();
+        assertEquals(0, runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.FAILURE).size());
+        assertEquals(1, runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.RESULTS).size());
+
+        List<MockFlowFile> results = runner.getFlowFilesForRelationship(ExecuteScriptMarkLogic.RESULTS);
+        assertEquals(1, results.size());
+
+        MockFlowFile result = results.get(0);
+        String resultValue = new String(runner.getContentAsByteArray(result));
+        assertEquals("2", resultValue, "The script is expected to return the value 2");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <nifi.version>1.15.3</nifi.version>
-        <marklogicnar.version>1.15.3</marklogicnar.version>
+        <marklogicnar.version>1.15.3.1</marklogicnar.version>
         <!-- MarkLogic Client 5.5.0 is required for DHF 5.4.x projects to continue to work -->
         <marklogicclientapi.version>5.5.0</marklogicclientapi.version>
         <mljavaclientutil.version>4.3.1</mljavaclientutil.version>


### PR DESCRIPTION
Thank you for submitting a contribution to marklogic-community/marklogic-nifi-incubator.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a github ticket associated with this PR? Is it referenced 
     in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under nifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under nifi-assembly?
- [ ] If adding new Properties, have you added .displayName in addition to .name (programmatic access) for each of the new properties?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?